### PR TITLE
Add server-side subscription enforcement and rate limits

### DIFF
--- a/client/src/app/api/features/books/[bookId]/route.ts
+++ b/client/src/app/api/features/books/[bookId]/route.ts
@@ -3,6 +3,8 @@ import { getServerSession } from "next-auth/next";
 import clientPromise from "../../../../../lib/mongodb";
 import { ObjectId } from "mongodb";
 import { authOptions } from "@/lib/authOptions";
+import { isProUser } from "@/lib/subscriptionCheck";
+import { hitRateLimit } from "@/lib/rateLimit";
 
 interface Book {
   _id: ObjectId;
@@ -54,6 +56,14 @@ export async function GET(
         { message: "Invalid user identifier format in session" },
         { status: 400 }
       );
+    }
+
+    if (hitRateLimit(`book-${userId}`)) {
+      return NextResponse.json({ message: "Too many requests" }, { status: 429 });
+    }
+
+    if (!(await isProUser(userId))) {
+      return NextResponse.json({ message: "Pro subscription required" }, { status: 403 });
     }
 
     const userObjectId = new ObjectId(userId);
@@ -117,6 +127,14 @@ export async function PUT(
         { message: "Invalid user identifier format in session" },
         { status: 400 }
       );
+    }
+
+    if (hitRateLimit(`book-${userId}`)) {
+      return NextResponse.json({ message: "Too many requests" }, { status: 429 });
+    }
+
+    if (!(await isProUser(userId))) {
+      return NextResponse.json({ message: "Pro subscription required" }, { status: 403 });
     }
 
     const userObjectId = new ObjectId(userId);
@@ -370,6 +388,14 @@ export async function DELETE(
         { message: "Invalid user identifier format in session" },
         { status: 400 }
       );
+    }
+
+    if (hitRateLimit(`book-${userId}`)) {
+      return NextResponse.json({ message: "Too many requests" }, { status: 429 });
+    }
+
+    if (!(await isProUser(userId))) {
+      return NextResponse.json({ message: "Pro subscription required" }, { status: 403 });
     }
 
     const userObjectId = new ObjectId(userId);

--- a/client/src/app/api/features/books/route.ts
+++ b/client/src/app/api/features/books/route.ts
@@ -3,6 +3,8 @@ import { getServerSession } from "next-auth/next";
 import clientPromise from "../../../../lib/mongodb";
 import { ObjectId } from "mongodb";
 import { authOptions } from "@/lib/authOptions";
+import { isProUser } from "@/lib/subscriptionCheck";
+import { hitRateLimit } from "@/lib/rateLimit";
 
 interface Book {
   _id: ObjectId;
@@ -53,6 +55,14 @@ export async function GET() {
     if (!isValidObjectId(userId)) {
       return NextResponse.json({ message: "Invalid user identifier" }, { status: 400 });
     }
+
+    if (hitRateLimit(`books-list-${userId}`)) {
+      return NextResponse.json({ message: "Too many requests" }, { status: 429 });
+    }
+
+    if (!(await isProUser(userId))) {
+      return NextResponse.json({ message: "Pro subscription required" }, { status: 403 });
+    }
     const userObjectId = new ObjectId(userId);
 
     const client = await clientPromise;
@@ -83,6 +93,13 @@ export async function POST(request: NextRequest) {
     const userId = session.user.id;
     if (!isValidObjectId(userId)) {
       return NextResponse.json({ message: "Invalid user identifier" }, { status: 400 });
+    }
+    if (hitRateLimit(`books-${userId}`)) {
+      return NextResponse.json({ message: "Too many requests" }, { status: 429 });
+    }
+
+    if (!(await isProUser(userId))) {
+      return NextResponse.json({ message: "Pro subscription required" }, { status: 403 });
     }
     const userObjectId = new ObjectId(userId);
 

--- a/client/src/lib/rateLimit.ts
+++ b/client/src/lib/rateLimit.ts
@@ -1,0 +1,30 @@
+interface RateLimitData {
+  count: number;
+  reset: number;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __rateLimitStore: Map<string, RateLimitData> | undefined;
+}
+
+const store: Map<string, RateLimitData> =
+  global.__rateLimitStore || (global.__rateLimitStore = new Map());
+
+export function hitRateLimit(
+  key: string,
+  limit = 60,
+  windowMs = 60_000
+): boolean {
+  const now = Date.now();
+  const entry = store.get(key);
+  if (!entry || entry.reset <= now) {
+    store.set(key, { count: 1, reset: now + windowMs });
+    return false;
+  }
+  if (entry.count >= limit) {
+    return true;
+  }
+  entry.count += 1;
+  return false;
+}

--- a/client/src/lib/subscriptionCheck.ts
+++ b/client/src/lib/subscriptionCheck.ts
@@ -1,0 +1,12 @@
+import connectDB from "./mongoose";
+import User from "@/app/models/User";
+
+/**
+ * Ensure the user has an active subscription.
+ * Returns true if the user is active, false otherwise.
+ */
+export async function isProUser(userId: string): Promise<boolean> {
+  await connectDB();
+  const user = await User.findById(userId).select("subscriptionStatus").exec();
+  return user?.subscriptionStatus === "active";
+}


### PR DESCRIPTION
## Summary
- check subscription status in journal and book API routes
- add simple in-memory rate limiter
- ensure protected endpoints require active subscription

## Testing
- `npm test` *(fails: Missing script)*
- `cd server && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844583439f4833291236db93a84422b